### PR TITLE
Apply crimson theme to UI

### DIFF
--- a/Editor/FilterTableRow.cpp
+++ b/Editor/FilterTableRow.cpp
@@ -101,22 +101,22 @@ void FilterTableRow::paintEvent(QPaintEvent*)
 
 	bool dark = GUIHelper::isDarkMode();
 
-	QColor color;
-	if (table->getSelectedItems().contains(item))
-	{
-		if (table->getFocusedItem() == item)
-			color = dark ? QColor(44, 111, 222) : QColor(64, 136, 255);
-		else
-			color = dark ? QColor(34, 86, 171) : QColor(97, 143, 219);
-	}
-	else
-	{
-		if (table->getFocusedItem() == item)
-			color = dark ? QColor(100, 100, 100) : QColor(160, 160, 160);
-		else
-			color = dark ? QColor(80, 80, 80) : QColor(180, 180, 180);
-	}
-	painter.setPen(color);
+       QColor color;
+       if (table->getSelectedItems().contains(item))
+       {
+               if (table->getFocusedItem() == item)
+                       color = dark ? QColor(180, 0, 40) : QColor(220, 20, 60);
+               else
+                       color = dark ? QColor(140, 0, 30) : QColor(190, 30, 70);
+       }
+       else
+       {
+               if (table->getFocusedItem() == item)
+                       color = dark ? QColor(100, 100, 100) : QColor(160, 160, 160);
+               else
+                       color = dark ? QColor(80, 80, 80) : QColor(180, 180, 180);
+       }
+       painter.setPen(color);
 
 	QLinearGradient gradient(r.topLeft(), r.bottomLeft());
 	gradient.setColorAt(0, dark ? QColor(70,70,70) : QColor(255, 255, 255));

--- a/Editor/guis/ChannelFilterGUIChannelItem.cpp
+++ b/Editor/guis/ChannelFilterGUIChannelItem.cpp
@@ -34,7 +34,7 @@ void ChannelFilterGUIChannelItem::paint(QPainter* painter, const QStyleOptionGra
 
 	if (isSelected())
 	{
-		color = QColor(176, 229, 255);
+		color = QColor(255, 176, 176);
 	}
 	else
 	{


### PR DESCRIPTION
## Summary
- Replace blue highlight colors in filter table rows with crimson
- Use crimson tones for selected channel filter items

## Testing
- `g++ -fsyntax-only Editor/FilterTableRow.cpp` *(fails: QToolBar: No such file or directory)*
- `g++ -fsyntax-only Editor/guis/ChannelFilterGUIChannelItem.cpp` *(fails: QPainter: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68941fbd861c832ba697107ec39ee448